### PR TITLE
Fix crash on update from `PowerDelta`

### DIFF
--- a/TasmotaInverter.py
+++ b/TasmotaInverter.py
@@ -251,9 +251,11 @@ class TasmotaInverterService:
                         self.inverter.power = float(jsonpayload["ENERGY"]["Power"])
                         self.inverter.current = float(jsonpayload["ENERGY"]["Current"])
                         self.inverter.voltage = float(jsonpayload["ENERGY"]["Voltage"])
-                        self.inverter.temperature = float(jsonpayload["ESP32"]["Temperature"])
                         self.inverter.apparent_power = float(jsonpayload["ENERGY"]["ApparentPower"])
 
+                        # Update temperature only if it exists in the payload
+                        if "ESP32" in jsonpayload and "Temperature" in jsonpayload["ESP32"]:
+                            self.inverter.temperature = float(jsonpayload["ESP32"]["Temperature"])
             else:
                 logging.debug("Topic not in configurd topics. This shouldn't be happen")
 


### PR DESCRIPTION
Tasmota does not officially support intervals shorter than 10 seconds for the `TelePeriod` command.
This means, we get slower updates on the Venus OS.

There is however a `PowerDelta`command setting in Tasmota, which allows you to configure a threshold for the power change that triggers a telemetry update. 

With this, we can get real-time like event updates during load change based on the threshold we set.
With this enabled, we can get more accurate look on current power usage on the Venus OS GUI.

The thing is, with it enabled, the app crashes. The crash is caused by missing `Temperature` property in the `SENSOR` payload. We still get it from `TelePeriod` payload, but it's missing when `PowerDelta` sends it.

Below is the comparison.

Normal `SENSOR` value:
```json
{
  "Time": "2025-06-12T17:57:18",
  "ENERGY": {
    "TotalStartTime": "2025-06-12T13:30:07",
    "Total": 0.251,
    "Yesterday": 0.002,
    "Today": 0.250,
    "Period": 0,
    "Power": 1,
    "ApparentPower": 12,
    "ReactivePower": 12,
    "Factor": 0.09,
    "Voltage": 225,
    "Current": 0.053
  },
  "ESP32": {
    "Temperature": 70.6
  },
  "TempUnit": "C"
}
```

`SENSOR` value from `PowerDelta` update:
```json
{
  "Time": "2025-06-12T17:57:01",
  "ENERGY": {
    "TotalStartTime": "2025-06-12T13:30:07",
    "Total": 0.251,
    "Yesterday": 0.002,
    "Today": 0.250,
    "Power": 42,
    "ApparentPower": 42,
    "ReactivePower": 0,
    "Factor": 1.00,
    "Voltage": 222,
    "Current": 0.036
  }
}
```

The fix is really simple. Just check if the temperature exists in the payload before trying to udpate it.